### PR TITLE
ci: skip building the vapoursynth Python package

### DIFF
--- a/.github/actions/setup-vapoursynth/action.yml
+++ b/.github/actions/setup-vapoursynth/action.yml
@@ -57,13 +57,9 @@ runs:
         make -j$(nproc)
         sudo make install -j$(nproc)
         sudo mkdir -p /usr/lib/vapoursynth
-        python setup.py sdist -d sdist
-        mkdir empty
-        pushd empty
-        pip install vapoursynth --no-index --find-links ../sdist
-        popd
         popd
         rm -rf vapoursynth
+        pip install vapoursynth==${{ inputs.vapoursynth-version }}
 
     - name: Verify VapourSynth install
       shell: python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,11 @@ on:
     branches:
       - main
     paths:
+      - '.github/actions/**'
       - '**.py'
   pull_request:
     paths:
+      - '.github/actions/**'
       - '**.py'
 
 jobs:


### PR DESCRIPTION
Just fetch it from pypi.